### PR TITLE
fix(monorepo): locale issue & png balance issue in breakdown modal

### DIFF
--- a/.changeset/brown-yaks-share.md
+++ b/.changeset/brown-yaks-share.md
@@ -1,0 +1,9 @@
+---
+'@honeycomb-finance/state-hooks': patch
+'@honeycomb-finance/portfolio': patch
+'@honeycomb-finance/elixir': patch
+'@honeycomb-finance/core': patch
+'@honeycomb-finance/sar': patch
+---
+
+Language Translation Issue fix and png balance

--- a/packages/core/src/ShowMore/ShowMore.tsx
+++ b/packages/core/src/ShowMore/ShowMore.tsx
@@ -1,6 +1,6 @@
+import { useTranslation } from '@honeycomb-finance/shared';
 import React, { useContext } from 'react';
 import { ChevronDown, ChevronUp } from 'react-feather';
-import { useTranslation } from '@honeycomb-finance/shared';
 import { ThemeContext } from 'styled-components';
 import { Text } from '../Text';
 import { Wrapper } from './styled';

--- a/packages/core/src/ShowMore/ShowMore.tsx
+++ b/packages/core/src/ShowMore/ShowMore.tsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { ChevronDown, ChevronUp } from 'react-feather';
-import { useTranslation } from 'react-i18next';
+import { useTranslation } from '@honeycomb-finance/shared';
 import { ThemeContext } from 'styled-components';
 import { Text } from '../Text';
 import { Wrapper } from './styled';

--- a/packages/elixir/src/components/LiquidityChartRangeInput/index.tsx
+++ b/packages/elixir/src/components/LiquidityChartRangeInput/index.tsx
@@ -1,10 +1,9 @@
 import { AutoColumn, ColumnCenter, Loader, Text } from '@honeycomb-finance/core';
-import { useChainId, wrappedCurrency } from '@honeycomb-finance/shared';
+import { useChainId, wrappedCurrency, useTranslation } from '@honeycomb-finance/shared';
 import { format } from 'd3';
 import { saturate } from 'polished';
 import React, { ReactNode, useCallback, useContext, useMemo } from 'react';
 import { BarChart2, CloudOff, Inbox } from 'react-feather';
-import { useTranslation } from 'react-i18next';
 import { batch } from 'react-redux';
 import { ThemeContext } from 'styled-components';
 import { useDensityChartData } from 'src/hooks/chart/evm';

--- a/packages/elixir/src/components/LiquidityChartRangeInput/index.tsx
+++ b/packages/elixir/src/components/LiquidityChartRangeInput/index.tsx
@@ -1,5 +1,5 @@
 import { AutoColumn, ColumnCenter, Loader, Text } from '@honeycomb-finance/core';
-import { useChainId, wrappedCurrency, useTranslation } from '@honeycomb-finance/shared';
+import { useChainId, useTranslation, wrappedCurrency } from '@honeycomb-finance/shared';
 import { format } from 'd3';
 import { saturate } from 'polished';
 import React, { ReactNode, useCallback, useContext, useMemo } from 'react';

--- a/packages/elixir/src/state/mint/hooks.ts
+++ b/packages/elixir/src/state/mint/hooks.ts
@@ -7,6 +7,7 @@ import {
   usePangolinWeb3,
   wrappedCurrency,
   wrappedCurrencyAmount,
+  useTranslation
 } from '@honeycomb-finance/shared';
 import { useCurrency, useCurrencyBalances, usePair } from '@honeycomb-finance/state-hooks';
 import {
@@ -28,7 +29,6 @@ import {
   tickToPrice,
 } from '@pangolindex/sdk';
 import { useCallback, useEffect, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import { usePool } from 'src/hooks/common';
 import { PoolState } from 'src/hooks/types';
 import { Bound, Field, initialState, useMintStateAtom } from './atom';

--- a/packages/elixir/src/state/mint/hooks.ts
+++ b/packages/elixir/src/state/mint/hooks.ts
@@ -5,9 +5,9 @@ import {
   tryParseAmount,
   useChainId,
   usePangolinWeb3,
+  useTranslation,
   wrappedCurrency,
   wrappedCurrencyAmount,
-  useTranslation
 } from '@honeycomb-finance/shared';
 import { useCurrency, useCurrencyBalances, usePair } from '@honeycomb-finance/state-hooks';
 import {

--- a/packages/portfolio/src/components/TokenInfo/TokenInfo.tsx
+++ b/packages/portfolio/src/components/TokenInfo/TokenInfo.tsx
@@ -1,6 +1,6 @@
 import { CurrencyLogo, Text, Tooltip } from '@honeycomb-finance/core';
 import { usePangolinWeb3, useTranslation } from '@honeycomb-finance/shared';
-import { useTokenBalancesHook, useTotalSupplyHook, useUSDCPriceHook } from '@honeycomb-finance/state-hooks';
+import { useTokenBalanceHook, useTotalSupplyHook, useUSDCPriceHook } from '@honeycomb-finance/state-hooks';
 import { TokenAmount } from '@pangolindex/sdk';
 import numeral from 'numeral';
 import React, { useContext } from 'react';
@@ -24,12 +24,11 @@ export default function TokenInfo({
 
   const chainId = token.chainId;
 
-  const useTokenBalance = useTokenBalancesHook[chainId];
+  const useTokenBalance = useTokenBalanceHook[chainId];
   const useUSDCPrice = useUSDCPriceHook[chainId];
   const useTotalSupply = useTotalSupplyHook[chainId];
 
-  const tokensBalance = useTokenBalance(account ?? undefined, [token]);
-  const balance = tokensBalance[token.address];
+  const balance = useTokenBalance(account ?? undefined, token);
 
   const tokenPrice = useUSDCPrice(token);
 

--- a/packages/sar/src/components/SarManageWidget/Unstake/index.tsx
+++ b/packages/sar/src/components/SarManageWidget/Unstake/index.tsx
@@ -89,7 +89,7 @@ export default function Unstake({ selectedOption, selectedPosition, onChange, on
       <Header>
         <TokenRow>
           <Text fontSize={24} fontWeight={500} color="text1" style={{ marginRight: '12px' }}>
-            {t('sarUnstake.unstaking', { balance: parsedAmount?.toSignificant(6) ?? 0 })}
+            {t('sarUnstake.unstaking', { balance: parsedAmount?.toSignificant(6) ?? 0 , symbol: png.symbol})}
           </Text>
           <CurrencyLogo currency={png} size={24} imageSize={48} />
         </TokenRow>

--- a/packages/sar/src/components/SarManageWidget/Unstake/index.tsx
+++ b/packages/sar/src/components/SarManageWidget/Unstake/index.tsx
@@ -89,7 +89,7 @@ export default function Unstake({ selectedOption, selectedPosition, onChange, on
       <Header>
         <TokenRow>
           <Text fontSize={24} fontWeight={500} color="text1" style={{ marginRight: '12px' }}>
-            {t('sarUnstake.unstaking', { balance: parsedAmount?.toSignificant(6) ?? 0 , symbol: png.symbol})}
+            {t('sarUnstake.unstaking', { balance: parsedAmount?.toSignificant(6) ?? 0, symbol: png.symbol })}
           </Text>
           <CurrencyLogo currency={png} size={24} imageSize={48} />
         </TokenRow>

--- a/packages/state-hooks/src/state/wallet/hooks/index.ts
+++ b/packages/state-hooks/src/state/wallet/hooks/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-lines */
 import { useDummyHook } from '@honeycomb-finance/shared';
 import { ChainId } from '@pangolindex/sdk';
-import { useETHBalances, useTokenBalances, useTokenBalance } from './evm';
-import { useHederaBalance, useHederaTokenBalances, useHederaTokenBalance } from './hedera';
-import { useNearBalance, useNearTokenBalances, useNearTokenBalance } from './near';
+import { useETHBalances, useTokenBalance, useTokenBalances } from './evm';
+import { useHederaBalance, useHederaTokenBalance, useHederaTokenBalances } from './hedera';
+import { useNearBalance, useNearTokenBalance, useNearTokenBalances } from './near';
 
 export type UseAccountBalanceHookType = {
   [chainId in ChainId]: typeof useETHBalances | typeof useNearBalance | typeof useHederaBalance | typeof useDummyHook;

--- a/packages/state-hooks/src/state/wallet/hooks/index.ts
+++ b/packages/state-hooks/src/state/wallet/hooks/index.ts
@@ -1,9 +1,9 @@
 /* eslint-disable max-lines */
 import { useDummyHook } from '@honeycomb-finance/shared';
 import { ChainId } from '@pangolindex/sdk';
-import { useETHBalances, useTokenBalances } from './evm';
-import { useHederaBalance, useHederaTokenBalances } from './hedera';
-import { useNearBalance, useNearTokenBalances } from './near';
+import { useETHBalances, useTokenBalances, useTokenBalance } from './evm';
+import { useHederaBalance, useHederaTokenBalances, useHederaTokenBalance } from './hedera';
+import { useNearBalance, useNearTokenBalances, useNearTokenBalance } from './near';
 
 export type UseAccountBalanceHookType = {
   [chainId in ChainId]: typeof useETHBalances | typeof useNearBalance | typeof useHederaBalance | typeof useDummyHook;
@@ -77,6 +77,46 @@ export const useTokenBalancesHook: UseTokenBalancesHookType = {
   [ChainId.MOONBEAM]: useTokenBalances,
   [ChainId.OP]: useTokenBalances,
   [ChainId.SKALE_BELLATRIX_TESTNET]: useTokenBalances,
+};
+
+export type UseTokenBalanceHookType = {
+  [chainId in ChainId]:
+    | typeof useTokenBalance
+    | typeof useNearTokenBalance
+    | typeof useHederaTokenBalance
+    | typeof useDummyHook;
+};
+
+export const useTokenBalanceHook: UseTokenBalanceHookType = {
+  [ChainId.FUJI]: useTokenBalance,
+  [ChainId.AVALANCHE]: useTokenBalance,
+  [ChainId.WAGMI]: useTokenBalance,
+  [ChainId.COSTON]: useTokenBalance,
+  [ChainId.SONGBIRD]: useTokenBalance,
+  [ChainId.FLARE_MAINNET]: useTokenBalance,
+  [ChainId.HEDERA_TESTNET]: useHederaTokenBalance,
+  [ChainId.HEDERA_MAINNET]: useHederaTokenBalance,
+  [ChainId.NEAR_MAINNET]: useNearTokenBalance,
+  [ChainId.NEAR_TESTNET]: useNearTokenBalance,
+  [ChainId.COSTON2]: useTokenBalance,
+  [ChainId.ETHEREUM]: useDummyHook,
+  [ChainId.POLYGON]: useDummyHook,
+  [ChainId.FANTOM]: useDummyHook,
+  [ChainId.XDAI]: useDummyHook,
+  [ChainId.BSC]: useDummyHook,
+  [ChainId.ARBITRUM]: useDummyHook,
+  [ChainId.CELO]: useDummyHook,
+  [ChainId.OKXCHAIN]: useDummyHook,
+  [ChainId.VELAS]: useDummyHook,
+  [ChainId.AURORA]: useDummyHook,
+  [ChainId.CRONOS]: useDummyHook,
+  [ChainId.FUSE]: useDummyHook,
+  [ChainId.MOONRIVER]: useDummyHook,
+  [ChainId.MOONBEAM]: useDummyHook,
+  [ChainId.OP]: useDummyHook,
+  [ChainId.EVMOS_TESTNET]: useTokenBalance,
+  [ChainId.EVMOS_MAINNET]: useTokenBalance,
+  [ChainId.SKALE_BELLATRIX_TESTNET]: useTokenBalance,
 };
 
 export * from './hedera';


### PR DESCRIPTION
Fixes below bugs

- The PNG balance is not reflected in the "Your PNG Breakdown" menu
- {{ symbol }} text appears in the summary page during Unstaking of a NFT
- Buttons text is incorrect on the elixir
- The message text is incorrect on the elixir