### PR TITLE
fix: governance show delegate vote button only for standard governance

### DIFF
--- a/.changeset/small-hounds-rule.md
+++ b/.changeset/small-hounds-rule.md
@@ -1,0 +1,5 @@
+---
+'@honeycomb-finance/governance': patch
+---
+
+show delegate vote button only for standard governance type

--- a/packages/governance/src/components/List/index.tsx
+++ b/packages/governance/src/components/List/index.tsx
@@ -16,7 +16,7 @@ import {
   useToggleDelegateModal,
   useTokenBalance,
 } from '@honeycomb-finance/state-hooks';
-import { JSBI, TokenAmount } from '@pangolindex/sdk';
+import { GovernanceType, JSBI, TokenAmount } from '@pangolindex/sdk';
 import React from 'react';
 import { useGetProposalsViaSubgraph } from 'src/hooks/common';
 import { useUserDelegate, useUserVotes } from 'src/hooks/evm';
@@ -59,7 +59,10 @@ const GovernanceList = () => {
 
   // show delegation option if they have have a balance, but have not delegated
   const showUnlockVoting = Boolean(
-    pngBalance && JSBI.notEqual(pngBalance.raw, JSBI.BigInt(0)) && userDelegatee === ZERO_ADDRESS,
+    pngBalance &&
+      JSBI.notEqual(pngBalance.raw, JSBI.BigInt(0)) &&
+      userDelegatee === ZERO_ADDRESS &&
+      chain.contracts?.governor?.type === GovernanceType.STANDARD,
   );
 
   function getAddress() {


### PR DESCRIPTION
## Summary

- **What** does this PR do?
  - Hide delegate vote button in governance page
- **Why** is this change needed?
  - We don't need to show delegate vote button for NFT governance.

---

## Type of Change

- [x] Bug Fix (a non-breaking change that solves an issue)
- [ ] New Feature (a non-breaking change that adds functionality)
- [ ] Breaking Change (fix or feature that would change existing functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] I have included Changeset
- [ ] I have included screenshot/video if required
- [x] I have tested my changes.
- [ ] I have made corresponding changes to the documentation if needed.
