### PR TITLE
fix: minichef subgraph hook & ignore farm if pair is null

### DIFF
--- a/.changeset/eleven-tools-suffer.md
+++ b/.changeset/eleven-tools-suffer.md
@@ -1,0 +1,5 @@
+---
+'@honeycomb-finance/pools': patch
+---
+
+fix useGetMinichefStakingInfosViaSubgraph hook crash due to null pair

--- a/packages/pools/src/hooks/minichef/hooks/evm.ts
+++ b/packages/pools/src/hooks/minichef/hooks/evm.ts
@@ -519,7 +519,7 @@ export const useGetMinichefStakingInfosViaSubgraph = (): MinichefStakingInfo[] =
       const rewardsAddress = farm?.rewarderAddress;
 
       // if is loading or not exist pair continue
-      if (extraPendingTokensRewardState?.loading || userPendingRewardState?.loading) {
+      if (extraPendingTokensRewardState?.loading || userPendingRewardState?.loading || !farm.pair) {
         continue;
       }
 


### PR DESCRIPTION
## Summary

- **What** does this PR do?
  - fix crash issue when someone use `useGetMinichefStakingInfosViaSubgraph` hook

---

## Details

- Subgraph indexed `https://snowtrace.io/address/0xd947375f78df5b8feea6814ecd999ee64507a057#readContract` pair which doesn't contain proper `token0` and `token1` method, so subgraph is not able to track pair properly, due to that pair was null and it was crashing the hook.

## Type of Change

- [x] Bug Fix (a non-breaking change that solves an issue)
- [ ] New Feature (a non-breaking change that adds functionality)
- [ ] Breaking Change (fix or feature that would change existing functionality)
- [ ] Refactoring (improves code quality but has no user-facing effect)
- [ ] Documentation Update (if none of the other choices apply)