### PR TITLE
fix: users TVL is invisible for Avalanche

### DIFF
--- a/.changeset/cool-bugs-carry.md
+++ b/.changeset/cool-bugs-carry.md
@@ -1,0 +1,5 @@
+---
+'@honeycomb-finance/pools': patch
+---
+
+fix: tvl in avalanche chain


### PR DESCRIPTION
## Summary

- **What** does this PR do?
  - This PR fixes the issue of invisibility of users' TVL on Avalanche farms. It also fixes the issue of invisibility of underlying assets.

Before: 
![image](https://github.com/Honeycomb-finance/components/assets/89118980/03b7875d-7370-4000-9987-a5f44b929af4)

After:
![image](https://github.com/Honeycomb-finance/components/assets/89118980/035bda14-9361-4f14-b36f-d9edc63bb2ad)


---

## Details

`minichefTvl` variable's unit is e-18 times smaller than wei. So, the calculated `totalStakedAmount` is so small and is displayed as $0.

## Type of Change

- [x] Bug Fix (a non-breaking change that solves an issue)


## Checklist

- [x] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [x] I have included Changeset
- [x] I have included screenshot/video if required
- [x] I have tested my changes.